### PR TITLE
Fix URL logic for dates after Q2 2021

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SEC13Flist
 Title: Routines to Work with Official List of SEC Section 13(f) Securities and Security Identifiers
-Version: 0.3.4.1
+Version: 0.3.4.2
 Authors@R: 
     person(given = "Yan",
            family = "Lyesin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # SEC13Flist 
 
+##0.3.4.2
+
+* Fixed rollover bug in url_file_func() to work properly in Q1 2022
+
 ##0.3.4.1
 
 * removed imports of xml2 and purrr

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,19 +94,17 @@ url_file_func <- function(YEAR_,
     url_file <-
       paste0("https://www.sec.gov/divisions/investment/", file_name)
   }
-  else
+  else if(YEAR_ < 2021 | (YEAR_ == 2021 & QUARTER_ <= 1))
   {
-    if (YEAR_ >= 2021 & QUARTER_ >= 2) {
-      file_name <- paste0('13flist', YEAR_, 'q', QUARTER_, '.pdf')
-      url_file <-
-        paste0("https://www.sec.gov/files/investment/",
-               file_name)
-    } else {
-      file_name <- paste0('13flist', YEAR_, 'q', QUARTER_, '.pdf')
-      url_file <-
-        paste0("https://www.sec.gov/divisions/investment/13f/",
-               file_name)
-    }
+    file_name <- paste0('13flist', YEAR_, 'q', QUARTER_, '.pdf')
+    url_file <-
+      paste0("https://www.sec.gov/divisions/investment/13f/",
+             file_name)
+  } else {
+    file_name <- paste0('13flist', YEAR_, 'q', QUARTER_, '.pdf')
+    url_file <-
+      paste0("https://www.sec.gov/files/investment/",
+             file_name)
   }
   return(url_file)
 }


### PR DESCRIPTION
url_file_func() logic to determine file path on sec.gov was incorrect starting in Q1 2022.
This fix repairs the "rollover" issue and also puts the "date decoders" in chronological order for easier readability.